### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/base_dockerfiles.yml
+++ b/.github/workflows/base_dockerfiles.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         BASE_OS_SOURCE_COMMIT: $GITHUB_SHA
       with:
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: imazen/imageflow_build_ubuntu16
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -50,7 +50,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: imazen/imageflow_build_ubuntu18
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -62,7 +62,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: imazen/imageflow_build_ubuntu18_debug
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore